### PR TITLE
feat/baseline-schema-drift

### DIFF
--- a/Bejebeje.DataAccess/Context/BbContext.cs
+++ b/Bejebeje.DataAccess/Context/BbContext.cs
@@ -28,9 +28,19 @@
 
     public DbSet<PointEvent> PointEvents { get; set; }
 
+    public DbSet<Like> Likes { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
       base.OnModelCreating(builder);
+
+      builder.Entity<Like>(entity =>
+      {
+        entity.ToTable("likes");
+
+        entity.HasKey(e => new { e.UserId, e.LyricId })
+          .HasName("primary_key");
+      });
 
       builder.Entity<LyricReport>(entity =>
       {

--- a/Bejebeje.DataAccess/Migrations/20260419120046_BaselineExistingSchema.Designer.cs
+++ b/Bejebeje.DataAccess/Migrations/20260419120046_BaselineExistingSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Bejebeje.DataAccess.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Bejebeje.DataAccess.Migrations
 {
     [DbContext(typeof(BbContext))]
-    partial class BbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419120046_BaselineExistingSchema")]
+    partial class BaselineExistingSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bejebeje.DataAccess/Migrations/20260419120046_BaselineExistingSchema.cs
+++ b/Bejebeje.DataAccess/Migrations/20260419120046_BaselineExistingSchema.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bejebeje.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class BaselineExistingSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_imported",
+                table: "lyrics",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_verified",
+                table: "lyrics",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "verified_at",
+                table: "lyrics",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "youtube_link",
+                table: "lyrics",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<char>(
+                name: "sex",
+                table: "artists",
+                type: "character(1)",
+                nullable: true,
+                oldClrType: typeof(char),
+                oldType: "character(1)");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_group",
+                table: "artists",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_imported",
+                table: "artists",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "likes",
+                columns: table => new
+                {
+                    user_id = table.Column<string>(type: "text", nullable: false),
+                    lyric_id = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("primary_key", x => new { x.user_id, x.lyric_id });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "likes");
+
+            migrationBuilder.DropColumn(
+                name: "is_imported",
+                table: "lyrics");
+
+            migrationBuilder.DropColumn(
+                name: "is_verified",
+                table: "lyrics");
+
+            migrationBuilder.DropColumn(
+                name: "verified_at",
+                table: "lyrics");
+
+            migrationBuilder.DropColumn(
+                name: "youtube_link",
+                table: "lyrics");
+
+            migrationBuilder.DropColumn(
+                name: "is_group",
+                table: "artists");
+
+            migrationBuilder.DropColumn(
+                name: "is_imported",
+                table: "artists");
+
+            migrationBuilder.AlterColumn<char>(
+                name: "sex",
+                table: "artists",
+                type: "character(1)",
+                nullable: false,
+                defaultValue: '\0',
+                oldClrType: typeof(char),
+                oldType: "character(1)",
+                oldNullable: true);
+        }
+    }
+}

--- a/Bejebeje.Domain/Artist.cs
+++ b/Bejebeje.Domain/Artist.cs
@@ -32,6 +32,10 @@
 
     public bool HasImage { get; set; }
 
-    public char Sex { get; set; }
+    public char? Sex { get; set; }
+
+    public bool? IsImported { get; set; }
+
+    public bool? IsGroup { get; set; }
   }
 }

--- a/Bejebeje.Domain/Like.cs
+++ b/Bejebeje.Domain/Like.cs
@@ -1,0 +1,9 @@
+namespace Bejebeje.Domain
+{
+  public class Like
+  {
+    public string UserId { get; set; }
+
+    public int LyricId { get; set; }
+  }
+}

--- a/Bejebeje.Domain/Lyric.cs
+++ b/Bejebeje.Domain/Lyric.cs
@@ -2,6 +2,7 @@
 {
   using System;
   using System.Collections.Generic;
+  using System.ComponentModel.DataAnnotations.Schema;
   using Interfaces;
 
   public class Lyric : IBaseEntity, IApprovable
@@ -23,6 +24,15 @@
     public bool IsDeleted { get; set; }
 
     public bool IsApproved { get; set; }
+
+    public bool? IsVerified { get; set; }
+
+    public DateTime? VerifiedAt { get; set; }
+
+    public bool? IsImported { get; set; }
+
+    [Column("youtube_link")]
+    public string YouTubeLink { get; set; }
 
     public int ArtistId { get; set; }
 


### PR DESCRIPTION
baseline domain entities against real prod schema

the main app's ef model had drifted from the real database — several columns added by the admin app (or by manual sql) were never captured in this repo's migrations, and the `likes` table had no entity at all despite being used via raw sql in services.

this commit aligns the domain and ef model with the actual prod schema so both can be extracted into a shared package in a follow-up.

- lyric: add IsVerified, VerifiedAt, IsImported, YouTubeLink (YouTubeLink uses [Column("youtube_link")] so snake-case naming doesn't produce you_tube_link)
- artist: add IsImported, IsGroup; widen Sex to char? to match the nullable prod column (many artists have null sex)
- new Like entity + DbSet, fluent config for composite pk named 'primary_key' (matches prod's literal constraint name — zero-risk alternative to renaming it to PK_likes)
- baseline migration BaselineExistingSchema captures all of the above

prod rollout: insert the migration row into __EFMigrationsHistory without running its sql, since the columns already exist. rehearsed locally — ef reports 'database is already up to date' afterwards.